### PR TITLE
Add the first unit-test suite + repair the broken smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,9 @@ iteration_*.md
 orthoroute.log.*
 orthoroute_debug.log
 orthoroute_debug.log.*
+
+# The tracked pytest suite lives in tests/. The rules above (test_*.py,
+# tests/, tests/*) would otherwise ignore it, so re-include every .py under
+# tests/ (test modules AND conftest.py, which holds the shared fixtures).
+!tests/
+!tests/*.py

--- a/main.py
+++ b/main.py
@@ -195,56 +195,73 @@ def run_headless_autoroute():
 
 
 def run_tiny_via_test():
-    """Run tiny 2-layer via test case to verify via pathfinding works."""
+    """Run tiny 4-layer via test case to verify via pathfinding works.
+
+    The board must have 4 copper layers: lateral routing edges exist only on
+    inner layers (build_graph excludes F.Cu and B.Cu), so a 2-layer board
+    yields an empty graph. Two SMD pads on F.Cu at a diagonal offset force
+    the routed path to use both inner layers (one H-only, one V-only), which
+    guarantees at least one via edge in the routing graph.
+    """
     try:
         config = setup_environment()
-        print("Starting tiny 2-layer via test...")
-        logging.info("Starting tiny 2-layer via test...")
+        print("Starting tiny 4-layer via test...")
+        logging.info("Starting tiny 4-layer via test...")
 
         from orthoroute.algorithms.manhattan.unified_pathfinder import UnifiedPathFinder, PathFinderConfig
         from orthoroute.domain.models.board import Board, Net, Pad, Component, Coordinate
 
-        # Create minimal 2-layer board with source L0, sink L1 at same (u,v)
         logging.info("[VIA-TEST] Creating minimal test board...")
 
-        # Create a simple board
         board = Board(id="via_test", name="Via Test Board")
-        board.layer_count = 2  # Only 2 layers for simple test
+        board.layer_count = 4  # F.Cu, In1.Cu, In2.Cu, B.Cu
 
-        # Create simple components and pads
-        pos = Coordinate(x=0.0, y=0.0)
-        comp1 = Component(id="comp1", reference="U1", value="Test", footprint="Test", position=pos)
-        comp2 = Component(id="comp2", reference="U2", value="Test", footprint="Test", position=pos)
+        # Two SMD pads on F.Cu, diagonally offset so the route needs both
+        # inner layers (H + V) and therefore at least one graph via edge.
+        pos1 = Coordinate(x=1.0, y=1.0)
+        pos2 = Coordinate(x=5.0, y=5.0)
+        comp1 = Component(id="comp1", reference="U1", value="Test", footprint="Test", position=pos1)
+        comp2 = Component(id="comp2", reference="U2", value="Test", footprint="Test", position=pos2)
 
-        # Pads at same position but different layers (requires via)
-        pad1 = Pad(id="pad1", component_id=comp1.id, position=pos, layer="F.Cu", size=(1.0, 1.0), net_id=None)
-        pad2 = Pad(id="pad2", component_id=comp2.id, position=pos, layer="B.Cu", size=(1.0, 1.0), net_id=None)
+        pad1 = Pad(id="pad1", component_id=comp1.id, position=pos1, layer="F.Cu", size=(1.0, 1.0), net_id=None)
+        pad2 = Pad(id="pad2", component_id=comp2.id, position=pos2, layer="F.Cu", size=(1.0, 1.0), net_id=None)
+        comp1.pads.append(pad1)
+        comp2.pads.append(pad2)
 
-        # Create a net connecting the pads
-        net = Net(id="net1", name="TEST_NET")
-        pad1.net_id = net.id
-        pad2.net_id = net.id
-        net.pad_ids = [pad1.id, pad2.id]
-        board.nets = [net]
+        # Net must carry the Pad objects: _calc_bounds and _parse_requests
+        # both walk net.pads, and the escape planner only portals pads that
+        # belong to a routable net.
+        net = Net(id="net1", name="TEST_NET", pads=[pad1, pad2])
+        board.add_component(comp1)
+        board.add_component(comp2)
+        board.add_net(net)
 
         logging.info(f"[VIA-TEST] Created test board with {len(board.nets)} nets")
 
         # Create UnifiedPathFinder with CPU-only mode
         pf_config = PathFinderConfig()
+        # The 3.0mm ROUTING_MARGIN is 7.5 grid steps at 0.4mm pitch, so pads
+        # land exactly half a pitch off-grid; allow the escape planner to snap
+        # them to the nearest column instead of rejecting at the 0.5 default.
+        pf_config.portal_x_snap_max = 0.75
         pf = UnifiedPathFinder(config=pf_config, use_gpu=False)
         logging.info(f"[VIA-TEST] Created UnifiedPathFinder with instance_tag={pf._instance_tag}")
 
-        # Build lattice
+        # Full live call sequence: skipping precompute_all_pad_escapes leaves
+        # nets portal-less and _parse_requests silently drops them.
         logging.info("[VIA-TEST] Building lattice/registry...")
         pf.initialize_graph(board)
         pf.map_all_pads(board)
+        pf.precompute_all_pad_escapes(board)
         pf.prepare_routing_runtime()
 
-        # Check via creation
-        if hasattr(pf, 'via_edge_ids') and len(pf.via_edge_ids) > 0:
-            logging.info(f"[VIA-TEST] Via edges created: {len(pf.via_edge_ids)}")
+        # Check via creation (graph edge_kind: 0 = lateral, 1 = via)
+        via_edge_count = int(pf._via_edges.sum()) if getattr(pf, '_via_edges', None) is not None else 0
+        if via_edge_count > 0:
+            logging.info(f"[VIA-TEST] Via edges created: {via_edge_count}")
         else:
             logging.error("[VIA-TEST] No via edges created!")
+            print("VIA TEST FAILED: No via edges created")
             sys.exit(1)
 
         # Route the test net
@@ -255,26 +272,27 @@ def run_tiny_via_test():
         logging.info("[VIA-TEST] Checking results...")
         tracks, vias = pf.emit_geometry(board)
 
-        # Verify via usage
-        via_eids = getattr(pf, 'via_edge_ids', [])
-        vias_used = 0
-        if hasattr(pf, 'owner') and hasattr(pf, 'e_is_via'):
-            owned_edges = np.where(pf.owner != -1)[0]
-            vias_used = int(np.sum(pf.e_is_via[owned_edges])) if len(owned_edges) > 0 else 0
+        # Verify via usage by counting layer changes along the routed path
+        routed_path = pf.net_paths.get(net.name, [])
+        plane_size = pf.lattice.x_steps * pf.lattice.y_steps
+        vias_used = sum(
+            1 for a, b in zip(routed_path, routed_path[1:])
+            if a // plane_size != b // plane_size
+        )
 
         logging.info(f"[VIA-TEST] Results: tracks={tracks} vias={vias} vias_used={vias_used}")
 
         # Assertions
-        assert len(via_eids) > 0, "No via edges created"
+        assert via_edge_count > 0, "No via edges created"
+        assert len(routed_path) >= 2, f"Net {net.name} was not routed (path={routed_path})"
         assert vias_used >= 1, f"No vias used in routing: vias_used={vias_used}"
 
-        owned_edges = np.where(pf.owner != -1)[0]
-        assert len(owned_edges) > 0, "No edges owned after routing"
+        present = pf.accounting.present
+        present = present.get() if hasattr(present, 'get') else present
+        present_nonzero = int(np.count_nonzero(present))
+        assert present_nonzero > 0, f"present usage is zero: {present_nonzero}"
 
-        present_nonzero = int(np.count_nonzero(pf.present_cost > 0))
-        assert present_nonzero > 0, f"present_cost is zero: {present_nonzero}"
-
-        print(f"VIA TEST PASSED: vias_used={vias_used} owned_edges={len(owned_edges)} present_nonzero={present_nonzero}")
+        print(f"VIA TEST PASSED: vias_used={vias_used} path_nodes={len(routed_path)} present_nonzero={present_nonzero}")
         logging.info("[VIA-TEST] All assertions passed!")
         sys.exit(0)
 

--- a/main.py
+++ b/main.py
@@ -663,24 +663,43 @@ def run_cli(board_file: str, output_dir: str = ".", config_path: Optional[str] =
 
         logging.info(f"Loaded board: {board.name} with {len(board.nets)} nets")
 
+        # Hard-fail on an empty parse: a 0-net/0-pad board means the file
+        # parser did not understand the input (previously this fell through
+        # to "No copper generated" with no hint at the real cause).
+        pad_count = sum(len(getattr(net, 'pads', [])) for net in board.nets)
+        if len(board.nets) == 0 or pad_count == 0:
+            msg = (
+                f"Parsed 0 routable content from {board_file} "
+                f"(nets={len(board.nets)}, pads-on-nets={pad_count}). "
+                "The file parser likely does not support this board's format."
+            )
+            logging.error(f"[CLI] {msg}")
+            print(f"CLI FAILED: {msg}", file=sys.stderr)
+            sys.exit(1)
+
         # Create UnifiedPathFinder (same as GUI) - FORCE CPU-ONLY
         pf = UnifiedPathFinder(config=PathFinderConfig(), use_gpu=False)
         logging.info(f"[CLI] Created UnifiedPathFinder with instance_tag={pf._instance_tag}")
 
-        # Use unified pipeline (SAME THREE CALLS AS GUI)
+        # Use unified pipeline (SAME CALL SEQUENCE AS GUI/headless).
+        # precompute_all_pad_escapes is mandatory: without portals,
+        # _parse_requests silently drops every net.
         logging.info("[CLI] Step 1: Building lattice & CSR...")
         pf.initialize_graph(board)
 
         logging.info("[CLI] Step 2: Mapping pads to lattice...")
         pf.map_all_pads(board)
 
-        logging.info("[CLI] Step 3: Preparing routing runtime...")
+        logging.info("[CLI] Step 3: Planning pad escapes (portals)...")
+        pf.precompute_all_pad_escapes(board)
+
+        logging.info("[CLI] Step 4: Preparing routing runtime...")
         pf.prepare_routing_runtime()
 
-        logging.info("[CLI] Step 4: Routing nets...")
+        logging.info("[CLI] Step 5: Routing nets...")
         pf.route_multiple_nets(board.nets)
 
-        logging.info("[CLI] Step 5: Emitting geometry...")
+        logging.info("[CLI] Step 6: Emitting geometry...")
         tracks, vias = pf.emit_geometry(board)
 
         logging.info(f"[CLI] Routing completed: {tracks} tracks, {vias} vias")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+"""Shared pytest fixtures for the OrthoRoute test suite.
+
+All tests here are KiCad-free and CPU-only: they exercise the engine's
+data structures and the file-format code directly, with no IPC connection
+and no GPU requirement.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+@pytest.fixture(scope="session")
+def repo_root() -> Path:
+    return REPO_ROOT
+
+
+def make_two_pad_board(layer_count: int = 4):
+    """Minimal synthetic Board: two F.Cu SMD pads on one net, diagonal offset.
+
+    Mirrors the --test-via smoke-test board; importable by any test that
+    needs a routable board object.
+    """
+    from orthoroute.domain.models.board import (
+        Board, Component, Coordinate, Net, Pad,
+    )
+
+    board = Board(id="test_board", name="Test Board")
+    board.layer_count = layer_count
+
+    pos1 = Coordinate(x=1.0, y=1.0)
+    pos2 = Coordinate(x=5.0, y=5.0)
+    comp1 = Component(id="comp1", reference="U1", value="T", footprint="T", position=pos1)
+    comp2 = Component(id="comp2", reference="U2", value="T", footprint="T", position=pos2)
+    pad1 = Pad(id="pad1", component_id="comp1", position=pos1, layer="F.Cu",
+               size=(1.0, 1.0), net_id=None)
+    pad2 = Pad(id="pad2", component_id="comp2", position=pos2, layer="F.Cu",
+               size=(1.0, 1.0), net_id=None)
+    comp1.pads.append(pad1)
+    comp2.pads.append(pad2)
+    net = Net(id="net1", name="TEST_NET", pads=[pad1, pad2])
+    board.add_component(comp1)
+    board.add_component(comp2)
+    board.add_net(net)
+    return board

--- a/tests/test_engine_smoke.py
+++ b/tests/test_engine_smoke.py
@@ -1,0 +1,97 @@
+"""End-to-end CPU-only engine smoke test (pytest twin of --test-via).
+
+Routes one two-pad net on a synthetic 4-layer board through the full live
+call sequence. This is the KiCad-free gate every backend change must pass.
+"""
+
+import numpy as np
+import pytest
+
+from orthoroute.algorithms.manhattan.unified_pathfinder import (
+    PathFinderConfig,
+    UnifiedPathFinder,
+)
+
+from conftest import make_two_pad_board
+
+
+@pytest.fixture(scope="module")
+def routed():
+    """Route the synthetic board once; tests inspect the result."""
+    board = make_two_pad_board(layer_count=4)
+    config = PathFinderConfig()
+    # 3.0mm ROUTING_MARGIN = 7.5 grid steps: pads sit half a pitch off-grid,
+    # so allow the escape planner to snap them (see --test-via).
+    config.portal_x_snap_max = 0.75
+    pf = UnifiedPathFinder(config=config, use_gpu=False)
+
+    pf.initialize_graph(board)
+    pf.map_all_pads(board)
+    pf.precompute_all_pad_escapes(board)
+    pf.prepare_routing_runtime()
+    pf.route_multiple_nets(board.nets)
+    tracks, vias = pf.emit_geometry(board)
+    return pf, board, tracks, vias
+
+
+def test_net_routed(routed):
+    pf, board, _, _ = routed
+    path = pf.net_paths.get("TEST_NET", [])
+    assert len(path) >= 2
+
+
+def test_path_uses_via(routed):
+    pf, _, _, _ = routed
+    path = pf.net_paths["TEST_NET"]
+    plane = pf.lattice.x_steps * pf.lattice.y_steps
+    layer_changes = sum(1 for a, b in zip(path, path[1:]) if a // plane != b // plane)
+    assert layer_changes >= 1
+
+
+def test_path_respects_hv_discipline(routed):
+    """Every lateral step must follow its layer's legal axis."""
+    pf, _, _, _ = routed
+    path = pf.net_paths["TEST_NET"]
+    for a, b in zip(path, path[1:]):
+        ax, ay, az = pf.lattice.idx_to_coord(a)
+        bx, by, bz = pf.lattice.idx_to_coord(b)
+        if az == bz:  # lateral move
+            assert pf.lattice.is_legal_planar_edge(ax, ay, az, bx, by, bz) or \
+                   pf.lattice.is_legal_planar_edge(bx, by, bz, ax, ay, az)
+        else:  # via move: same (x, y)
+            assert (ax, ay) == (bx, by)
+
+
+def test_converged_no_overuse(routed):
+    pf, _, _, _ = routed
+    total, count = pf.accounting.compute_overuse(pf)
+    assert (total, count) == (0, 0)
+
+
+def test_geometry_emitted(routed):
+    _, _, tracks, vias = routed
+    assert tracks > 0
+    assert vias >= 1  # at least the escape/path vias
+
+
+def test_present_matches_canonical(routed):
+    pf, _, _, _ = routed
+    assert pf.accounting.verify_present_matches_canonical()
+
+
+def test_deterministic_across_runs(routed):
+    """Seeded RNG + stable sorts: a second identical run yields the same path."""
+    pf, _, _, _ = routed
+    first_path = list(pf.net_paths["TEST_NET"])
+
+    board2 = make_two_pad_board(layer_count=4)
+    config2 = PathFinderConfig()
+    config2.portal_x_snap_max = 0.75
+    pf2 = UnifiedPathFinder(config=config2, use_gpu=False)
+    pf2.initialize_graph(board2)
+    pf2.map_all_pads(board2)
+    pf2.precompute_all_pad_escapes(board2)
+    pf2.prepare_routing_runtime()
+    pf2.route_multiple_nets(board2.nets)
+
+    assert list(pf2.net_paths["TEST_NET"]) == first_path

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -1,0 +1,92 @@
+"""Tests for Lattice3D construction and the CSR routing graph.
+
+Pins the engine's core geometric invariants: flat node indexing, H/V layer
+discipline, legal via pairs, and the (documented) fact that 2-layer boards
+produce an empty routing graph because lateral edges exist only on inner
+layers.
+"""
+
+import numpy as np
+import pytest
+
+from orthoroute.algorithms.manhattan.unified_pathfinder import Lattice3D
+
+BOUNDS = (0.0, 0.0, 4.0, 4.0)  # 4x4 mm
+PITCH = 0.4
+
+
+@pytest.fixture(scope="module")
+def lattice4():
+    return Lattice3D(BOUNDS, PITCH, layers=4)
+
+
+class TestIndexing:
+    def test_node_index_roundtrip(self, lattice4):
+        for (x, y, z) in [(0, 0, 0), (3, 7, 1), (10, 10, 3)]:
+            idx = lattice4.node_idx(x, y, z)
+            assert lattice4.idx_to_coord(idx) == (x, y, z)
+
+    def test_flat_index_formula(self, lattice4):
+        # flat = layer*(x_steps*y_steps) + y*x_steps + x (CLAUDE.md invariant)
+        plane = lattice4.x_steps * lattice4.y_steps
+        assert lattice4.node_idx(2, 3, 1) == plane + 3 * lattice4.x_steps + 2
+
+    def test_num_nodes(self, lattice4):
+        assert lattice4.num_nodes == lattice4.x_steps * lattice4.y_steps * 4
+
+
+class TestLayerDiscipline:
+    def test_layer_directions(self, lattice4):
+        # F.Cu vertical (escape stubs), then layers alternate H/V by parity.
+        # B.Cu's entry is irrelevant: outer layers get no lateral edges.
+        assert lattice4.layer_dir == ["v", "h", "v", "h"]
+
+    def test_legal_planar_edges(self, lattice4):
+        # In1.Cu (z=1) is horizontal: +X moves legal, +Y moves not.
+        assert lattice4.is_legal_planar_edge(0, 0, 1, 1, 0, 1)
+        assert not lattice4.is_legal_planar_edge(0, 0, 1, 0, 1, 1)
+        # In2.Cu (z=2) is vertical: the opposite.
+        assert lattice4.is_legal_planar_edge(0, 0, 2, 0, 1, 2)
+        assert not lattice4.is_legal_planar_edge(0, 0, 2, 1, 0, 2)
+
+
+class TestViaPairs:
+    def test_four_layer_pairs(self, lattice4):
+        pairs = lattice4.get_legal_via_pairs(4)
+        # Inner layers {1,2} full blind/buried + F.Cu transitions, no B.Cu.
+        assert pairs == {(1, 2), (2, 1), (0, 1), (1, 0), (0, 2), (2, 0)}
+
+    def test_two_layer_pairs_empty(self, lattice4):
+        assert lattice4.get_legal_via_pairs(2) == set()
+
+
+class TestGraphBuild:
+    def test_four_layer_graph(self, lattice4):
+        graph = lattice4.build_graph(via_cost=0.7)
+        E = int(graph.indptr[-1])
+        assert E > 0
+        assert len(graph.indptr) == lattice4.num_nodes + 1
+        assert len(graph.indices) == E
+        assert len(graph.base_costs) == E
+
+        # edge_kind: 1 for via edges, 0 for lateral; both kinds must exist.
+        via_edges = int(np.sum(graph.edge_kind))
+        assert 0 < via_edges < E
+
+        # Expected lateral edge count: 2 directed edges per adjacent pair on
+        # each inner layer, along that layer's legal axis only.
+        xs, ys = lattice4.x_steps, lattice4.y_steps
+        expected_lateral = 2 * ys * (xs - 1) + 2 * xs * (ys - 1)  # z=1 (h) + z=2 (v)
+        assert E - via_edges == expected_lateral
+
+    def test_two_layer_graph_is_empty(self):
+        # Documented limitation: no inner layers -> no lateral edges, no via
+        # pairs -> build fails loudly rather than routing nothing.
+        lattice = Lattice3D(BOUNDS, PITCH, layers=2)
+        with pytest.raises(ValueError):
+            lattice.build_graph(via_cost=0.7)
+
+    def test_edge_costs_positive(self, lattice4):
+        graph = lattice4.build_graph(via_cost=0.7)
+        costs = np.asarray(graph.base_costs)
+        assert np.all(costs > 0)

--- a/tests/test_via_accounting.py
+++ b/tests/test_via_accounting.py
@@ -1,0 +1,70 @@
+"""Tests for EdgeAccountant: present/canonical bookkeeping and overuse.
+
+The PathFinder convergence invariant depends on `present` being rebuilt
+from committed nets every iteration and staying in sync with the canonical
+store; these tests pin that contract.
+"""
+
+import pytest
+
+from orthoroute.algorithms.manhattan.unified_pathfinder import EdgeAccountant
+
+
+@pytest.fixture
+def acct():
+    return EdgeAccountant(num_edges=10, use_gpu=False)
+
+
+class TestCommitClear:
+    def test_commit_updates_present_and_canonical(self, acct):
+        acct.commit_path([1, 2, 3])
+        assert acct.canonical == {1: 1, 2: 1, 3: 1}
+        assert list(acct.present[[1, 2, 3]]) == [1.0, 1.0, 1.0]
+        assert acct.verify_present_matches_canonical()
+
+    def test_double_commit_stacks(self, acct):
+        acct.commit_path([2, 3])
+        acct.commit_path([3, 4])
+        assert acct.canonical[3] == 2
+        assert acct.present[3] == 2.0
+        assert acct.verify_present_matches_canonical()
+
+    def test_clear_reverses_commit(self, acct):
+        acct.commit_path([1, 2])
+        acct.clear_path([1, 2])
+        assert acct.canonical == {}
+        assert float(acct.present.sum()) == 0.0
+        assert acct.verify_present_matches_canonical()
+
+    def test_clear_never_goes_negative(self, acct):
+        acct.clear_path([5])
+        assert 5 not in acct.canonical
+        assert acct.present[5] == 0.0
+
+    def test_refresh_from_canonical_rebuilds(self, acct):
+        acct.commit_path([1, 2, 2])
+        acct.present.fill(99.0)  # corrupt
+        acct.refresh_from_canonical()
+        assert acct.present[2] == 2.0
+        assert acct.present[0] == 0.0
+        assert acct.verify_present_matches_canonical()
+
+
+class TestOveruse:
+    def test_no_overuse_at_capacity(self, acct):
+        acct.commit_path([1, 2, 3])  # capacity is 1 everywhere
+        total, count = acct.compute_overuse()
+        assert (total, count) == (0, 0)
+
+    def test_overuse_counts_excess(self, acct):
+        acct.commit_path([1, 2])
+        acct.commit_path([2, 3])
+        acct.commit_path([2])
+        total, count = acct.compute_overuse()
+        assert total == 2  # edge 2 used 3x, capacity 1
+        assert count == 1
+
+    def test_mismatch_detected(self, acct):
+        acct.commit_path([1])
+        acct.present[1] = 5.0  # desync
+        assert not acct.verify_present_matches_canonical()


### PR DESCRIPTION
## What

Adds the first unit-test suite to the repo, and repairs the two smoke-test
entry points that were broken on every platform.

## Why

`CONTRIBUTING.md` lists tests as the **Critical Priority** ("The project has
zero unit tests. This is the biggest blocker to refactoring."). This starts
that suite — KiCad-free, CPU-only, **no new runtime dependencies** — and along
the way fixes two commands that silently did the wrong thing:

- `python main.py --test-via` built a **2-layer** board, which produces an
  empty routing graph (no via layers), so the self-test raised before it could
  test anything. Now uses a 4-layer board and the real engine call sequence.
- `cli` mode printed "No copper generated" and exited **0** when a board parsed
  to 0 nets, and skipped the mandatory `precompute_all_pad_escapes` step (which
  silently drops every net). Now it runs the full sequence and hard-fails
  (exit 1) on a 0-net parse.

It also fixes `.gitignore`, which ignored `test_*.py` and `tests/*` — actively
preventing *any* test suite from being tracked.

## Tests

- `test_lattice` — node count, H/V layer discipline, legal planar edges, legal
  via pairs.
- `test_via_accounting` — `EdgeAccountant` commit/clear symmetry, usage floored
  at 0, refresh-from-canonical, overuse counting at capacity.
- `test_engine_smoke` — the mandatory engine call sequence routes a trivial
  two-pad board end to end.
- `conftest.py` — shared fixtures + `make_two_pad_board` factory.

```
$ python -m pytest tests/
25 passed
```

No KiCad, no GPU, no network required.

## Checklist

- [x] Tests pass locally (25 passed on a clean clone)
- [x] No new runtime dependencies
- [x] PEP 8 / Google-style docstrings on new code
- [x] Fixes `.gitignore` so a fresh clone can collect the suite
