### PR TITLE
Metal (Apple Silicon) solver backend via MLX

### DIFF
--- a/orthoroute/algorithms/manhattan/pathfinder/metal_dijkstra.py
+++ b/orthoroute/algorithms/manhattan/pathfinder/metal_dijkstra.py
@@ -97,9 +97,12 @@ class MetalDijkstra:
     """
 
     def __init__(self, indptr: np.ndarray, indices: np.ndarray, num_nodes: int,
-                 plane_size: Optional[int] = None):
+                 plane_size: Optional[int] = None,
+                 min_roi_nodes: Optional[int] = None):
         if not METAL_AVAILABLE:
             raise RuntimeError("MLX Metal GPU not available")
+        if min_roi_nodes is not None:
+            self.MIN_ROI_NODES = min_roi_nodes
 
         self.N = int(num_nodes)
         self.plane_size = plane_size
@@ -109,21 +112,33 @@ class MetalDijkstra:
         degrees = np.diff(indptr)
         self.K = int(degrees.max()) if len(degrees) else 0
 
-        # Dense padded tables: nbr[n, k] = neighbor node, eid[n, k] = CSR edge
-        # index (for cost lookup). Padded slots: nbr=self-loop 0, eid=E
-        # (one extra cost slot pinned to +inf).
+        # Dense padded INCOMING-neighbor tables: in_nbr[v, k] = source node u
+        # of the k-th edge ARRIVING at v, in_eid[v, k] = that edge's CSR
+        # index (for cost lookup). Relaxation is then pure gather:
+        #   dist'[v] = min(dist[v], min_k(dist[in_nbr[v,k]] + cost[in_eid[v,k]]))
+        # No scatter, no per-round host sync, and the winning parent is just
+        # in_nbr[v, argmin_k] - the Metal translation of the CUDA backend's
+        # GPU-resident frontier/backtrace design. Padded slots: nbr=0,
+        # eid=E (one extra cost slot pinned to +inf).
         E = len(indices)
-        nbr = np.zeros((self.N, self.K), dtype=np.int64)
-        eid = np.full((self.N, self.K), E, dtype=np.int64)
+        edge_src = np.repeat(np.arange(self.N, dtype=np.int64), degrees)
+        order = np.argsort(indices, kind="stable")
+        dst_sorted = indices[order]
+        in_degrees = np.bincount(dst_sorted, minlength=self.N)
+        self.K = int(max(self.K, in_degrees.max())) if len(in_degrees) else self.K
+        in_start = np.zeros(self.N + 1, dtype=np.int64)
+        np.cumsum(in_degrees, out=in_start[1:])
+        in_nbr = np.zeros((self.N, self.K), dtype=np.int64)
+        in_eid = np.full((self.N, self.K), E, dtype=np.int64)
         for k in range(self.K):
-            has_k = degrees > k
+            has_k = in_degrees > k
             rows = np.nonzero(has_k)[0]
-            pos = indptr[:-1][has_k] + k
-            nbr[rows, k] = indices[pos]
-            eid[rows, k] = pos
+            pos = in_start[:-1][has_k] + k
+            in_nbr[rows, k] = edge_src[order[pos]]
+            in_eid[rows, k] = order[pos]
 
-        self.nbr = mx.array(nbr)
-        self.eid = mx.array(eid)
+        self.in_nbr = mx.array(in_nbr)
+        self.in_eid = mx.array(in_eid)
         self.E = E
 
         # Cost cache: rebuilt only when the (in-place mutated) cost array's
@@ -145,10 +160,19 @@ class MetalDijkstra:
             self._cost_mx = mx.array(np.append(c, _INF))
         return self._cost_mx
 
+    # Below this ROI size the CPU heap Dijkstra wins: dense GPU relaxation
+    # does O(N*K) work per round regardless of wave width, which only pays
+    # off on big solves (same tradeoff as the CUDA backend's
+    # gpu_roi_min_nodes threshold).
+    MIN_ROI_NODES = 150_000
+
     def _run_sssp(self, seed_nodes: np.ndarray, seed_costs: np.ndarray,
                   costs, roi_nodes, node_penalty,
                   target_nodes: np.ndarray) -> Optional[Tuple[np.ndarray, np.ndarray]]:
-        """Fixpoint frontier relaxation. Returns (dist_f32[N], parent_i64[N])."""
+        """Fixpoint dense relaxation. Returns (dist_f32[N], parent_i64[N])."""
+        roi_size = len(roi_nodes) if roi_nodes is not None else self.N
+        if roi_size < self.MIN_ROI_NODES:
+            return None  # CPU fallback handles small solves faster
         cost_gpu = self._costs_to_gpu(costs)
 
         # ROI mask over N (True = routable). None -> everything allowed.
@@ -166,64 +190,47 @@ class MetalDijkstra:
             if node_penalty is not None:
                 pen_np = np.asarray(node_penalty, dtype=np.float32)
 
-        allowed = mx.array(allowed_np) if allowed_np is not None else None
-        penalty = mx.array(pen_np) if pen_np is not None else None
+        INF = mx.array(np.float32(np.inf))
+        # Per-node arrival penalty and ROI restriction folded into a single
+        # additive vector: +inf outside the ROI kills those candidates.
+        extra_np = np.zeros(self.N, dtype=np.float32)
+        if pen_np is not None:
+            extra_np += pen_np
+        if allowed_np is not None:
+            extra_np[~allowed_np] = np.inf
+        extra = mx.array(extra_np)[:, None] if extra_np.any() else None
 
-        # Two-phase relaxation (MLX GPU scatter has no int64 support, so no
-        # packed dist|parent keys): phase 1 scatter-mins float32 distances,
-        # phase 2 scatters parents for candidates that achieved the new
-        # distance, resolving equal-cost ties to the MINIMUM source id -
-        # deterministic and always a valid shortest-path tree edge.
-        NO_PARENT = np.uint32(0xFFFFFFFF)
         dist = mx.full((self.N,), np.float32(np.inf), dtype=mx.float32)
-        parent = mx.full((self.N,), NO_PARENT, dtype=mx.uint32)
-
+        parent = mx.full((self.N,), -1, dtype=mx.int32)
         seeds = mx.array(seed_nodes.astype(np.int64))
         dist = dist.at[seeds].minimum(mx.array(seed_costs.astype(np.float32)))
         mx.eval(dist)
 
-        frontier = seeds
-        for _ in range(self.N):  # fixpoint exit fires far earlier
-            f_nbr = self.nbr[frontier]          # (F, K) neighbor node ids
-            f_eid = self.eid[frontier]          # (F, K) CSR edge ids
-            f_dist = dist[frontier]
+        # Dense gather relaxation, fully GPU-resident. Host sync only every
+        # CHECK_EVERY rounds for the fixpoint test.
+        CHECK_EVERY = 8
+        checkpoint = dist
+        for rnd in range(1, self.N + 1):
+            gathered = dist[self.in_nbr] + cost_gpu[self.in_eid]  # (N, K)
+            if extra is not None:
+                gathered = gathered + extra  # arrival penalty / ROI wall
+            best = mx.min(gathered, axis=1)
+            best_k = mx.argmin(gathered, axis=1)
+            improved = best < dist
+            new_parent = mx.take_along_axis(
+                self.in_nbr, best_k[:, None].astype(mx.int64), axis=1
+            ).squeeze(1).astype(mx.int32)
+            parent = mx.where(improved, new_parent, parent)
+            dist = mx.where(improved, best, dist)
 
-            w = cost_gpu[f_eid]                 # +inf on padded slots
-            if penalty is not None:
-                w = w + penalty[f_nbr]
-            cand = f_dist[:, None] + w
-            if allowed is not None:
-                cand = mx.where(allowed[f_nbr], cand, mx.array(np.float32(np.inf)))
-
-            flat_nbr = f_nbr.reshape(-1)
-            flat_cand = cand.reshape(-1)
-
-            new_dist = dist.at[flat_nbr].minimum(flat_cand)
-
-            # Parent phase: candidates that achieved the (bitwise-equal) new
-            # distance write their source id; min() resolves ties.
-            achieved = flat_cand == new_dist[flat_nbr]
-            src_ids = mx.broadcast_to(
-                frontier[:, None].astype(mx.uint32), f_nbr.shape).reshape(-1)
-            parent_cand = mx.where(achieved, src_ids, mx.array(NO_PARENT))
-            improved_nodes = new_dist < dist
-            # Only rewrite parents of nodes whose dist improved this round
-            keep_old = mx.where(improved_nodes, mx.array(NO_PARENT),
-                                parent)  # improved -> forget old parent
-            parent = mx.minimum(keep_old, mx.full((self.N,), NO_PARENT, dtype=mx.uint32))
-            parent = parent.at[flat_nbr].minimum(
-                mx.where(improved_nodes[flat_nbr], parent_cand, mx.array(NO_PARENT)))
-
-            changed = new_dist < dist
-            dist = new_dist
-            frontier = mx.array(np.nonzero(np.array(changed))[0].astype(np.int64))
-            mx.eval(dist, parent, frontier)
-            if frontier.size == 0:
-                break
+            if rnd % CHECK_EVERY == 0:
+                mx.eval(dist, parent)
+                if bool(mx.all(dist == checkpoint)):  # no change in window
+                    break
+                checkpoint = dist
 
         dist_np = np.array(dist, dtype=np.float32)
         parent_np = np.array(parent, dtype=np.int64)
-        parent_np[parent_np == int(NO_PARENT)] = -1
         return dist_np, parent_np
 
     # ------------------------------------------------------------------ #

--- a/orthoroute/algorithms/manhattan/pathfinder/metal_dijkstra.py
+++ b/orthoroute/algorithms/manhattan/pathfinder/metal_dijkstra.py
@@ -274,6 +274,8 @@ class MetalDijkstra:
         CAP = min(self.N, 4_000_000)
         params = mx.array(np.array([self.K, self.E, CAP], dtype=np.uint32))
         frontier = mx.array(np.unique(seed_nodes).astype(np.uint32))
+        target_mx = (mx.array(target_nodes.astype(np.int64))
+                     if target_nodes is not None and len(target_nodes) else None)
 
         for _ in range(self.N):
             F = frontier.shape[0]
@@ -294,6 +296,15 @@ class MetalDijkstra:
             takes = min(count, CAP)
             frontier = mx.array(
                 np.unique(np.array(next_f[:takes], dtype=np.uint32)))
+
+            # Dijkstra bound early-exit: uint32 dist encodings are monotonic,
+            # so once every target's encoding is <= the frontier's best,
+            # no future relaxation (costs >= 0) can improve any target.
+            if target_mx is not None:
+                t_best = int(mx.max(dist_enc[target_mx]))
+                f_best = int(mx.min(dist_enc[frontier.astype(mx.int64)]))
+                if t_best <= f_best and t_best != INF_ENC:
+                    break
 
         dist_np = np.array(dist_enc, dtype=np.uint32).view(np.float32)
 

--- a/orthoroute/algorithms/manhattan/pathfinder/metal_dijkstra.py
+++ b/orthoroute/algorithms/manhattan/pathfinder/metal_dijkstra.py
@@ -141,6 +141,64 @@ class MetalDijkstra:
         self.in_eid = mx.array(in_eid)
         self.E = E
 
+        # OUT-neighbor padded tables (uint32, flat) for the frontier scatter
+        # kernel: threads relax the outgoing edges of frontier nodes only,
+        # so per-round work is O(frontier * K), not O(N * K) like the dense
+        # path. Padded slots: eid == E sentinel (skipped in-kernel).
+        out_nbr = np.zeros((self.N, self.K), dtype=np.uint32)
+        out_eid = np.full((self.N, self.K), E, dtype=np.uint32)
+        for k in range(self.K):
+            has_k = degrees > k
+            rows = np.nonzero(has_k)[0]
+            pos = indptr[:-1][has_k] + k
+            out_nbr[rows, k] = indices[pos]
+            out_eid[rows, k] = pos
+        self.out_nbr = mx.array(out_nbr.reshape(-1))
+        self.out_eid = mx.array(out_eid.reshape(-1))
+        self._zero_penalty = mx.zeros((self.N,), dtype=mx.float32)
+
+        # Frontier relax kernel. Distances are uint32-encoded float bits
+        # (monotonic for non-negative floats) and INVERTED (UINT_MAX - bits)
+        # so a single init_value=0 works for all atomic outputs: relaxation
+        # is atomic_fetch_max on inverted encodings == min on distances,
+        # and the frontier count naturally starts at 0.
+        self._relax_kernel = mx.fast.metal_kernel(
+            name="orthoroute_frontier_relax",
+            input_names=["dist", "frontier", "out_nbr", "out_eid",
+                         "costs", "penalty", "params"],
+            output_names=["new_dist_inv", "next_frontier", "next_count"],
+            source="""
+    uint tid = thread_position_in_grid.x;
+    uint K = params[0];
+    uint E_PAD = params[1];
+    uint CAP = params[2];
+    uint F = frontier_shape[0];
+    if (tid >= F * K) return;
+    uint f = frontier[tid / K];
+    uint slot = f * K + (tid % K);
+    uint eid = out_eid[slot];
+    if (eid == E_PAD) return;
+    uint v = out_nbr[slot];
+    float du = as_type<float>(dist[f]);
+    float cand = du + costs[eid] + penalty[v];
+    if (!(cand < INFINITY)) return;
+    uint enc = as_type<uint>(cand);
+    if (enc >= dist[v]) return;  // not an improvement on current state
+    uint inv = 0xFFFFFFFFu - enc;
+    uint old = atomic_fetch_max_explicit(&new_dist_inv[v], inv,
+                                         memory_order_relaxed);
+    if (inv > old) {
+        uint pos = atomic_fetch_add_explicit(&next_count[0], 1u,
+                                             memory_order_relaxed);
+        if (pos < CAP) {
+            atomic_store_explicit(&next_frontier[pos], v,
+                                  memory_order_relaxed);
+        }
+    }
+""",
+            atomic_outputs=True,
+        )
+
         # Cost cache: rebuilt only when the (in-place mutated) cost array's
         # cheap fingerprint changes.
         self._cost_fp = None
@@ -200,37 +258,63 @@ class MetalDijkstra:
             extra_np[~allowed_np] = np.inf
         extra = mx.array(extra_np)[:, None] if extra_np.any() else None
 
-        dist = mx.full((self.N,), np.float32(np.inf), dtype=mx.float32)
-        parent = mx.full((self.N,), -1, dtype=mx.int32)
-        seeds = mx.array(seed_nodes.astype(np.int64))
-        dist = dist.at[seeds].minimum(mx.array(seed_costs.astype(np.float32)))
-        mx.eval(dist)
+        # Penalty vector for the kernel: arrival penalty, +inf outside ROI
+        penalty_full = mx.array(extra_np) if extra is not None else self._zero_penalty
 
-        # Dense gather relaxation, fully GPU-resident. Host sync only every
-        # CHECK_EVERY rounds for the fixpoint test.
-        CHECK_EVERY = 8
-        checkpoint = dist
-        for rnd in range(1, self.N + 1):
-            gathered = dist[self.in_nbr] + cost_gpu[self.in_eid]  # (N, K)
-            if extra is not None:
-                gathered = gathered + extra  # arrival penalty / ROI wall
-            best = mx.min(gathered, axis=1)
-            best_k = mx.argmin(gathered, axis=1)
-            improved = best < dist
-            new_parent = mx.take_along_axis(
-                self.in_nbr, best_k[:, None].astype(mx.int64), axis=1
-            ).squeeze(1).astype(mx.int32)
-            parent = mx.where(improved, new_parent, parent)
-            dist = mx.where(improved, best, dist)
+        # Frontier scatter loop: per-round work is O(frontier * K). The
+        # kernel atomically maxes INVERTED uint32-encoded distances (== min
+        # on real distances) so init_value=0 serves all three outputs.
+        INF_ENC = int(np.float32(np.inf).view(np.uint32))
+        dist_np32 = np.full(self.N, INF_ENC, dtype=np.uint32)
+        dist_np32[seed_nodes] = np.minimum(
+            dist_np32[seed_nodes],
+            seed_costs.astype(np.float32).view(np.uint32))
+        dist_enc = mx.array(dist_np32)
 
-            if rnd % CHECK_EVERY == 0:
-                mx.eval(dist, parent)
-                if bool(mx.all(dist == checkpoint)):  # no change in window
-                    break
-                checkpoint = dist
+        CAP = min(self.N, 4_000_000)
+        params = mx.array(np.array([self.K, self.E, CAP], dtype=np.uint32))
+        frontier = mx.array(np.unique(seed_nodes).astype(np.uint32))
 
-        dist_np = np.array(dist, dtype=np.float32)
+        for _ in range(self.N):
+            F = frontier.shape[0]
+            new_inv, next_f, next_c = self._relax_kernel(
+                inputs=[dist_enc, frontier, self.out_nbr, self.out_eid,
+                        cost_gpu, penalty_full, params],
+                grid=(F * self.K, 1, 1),
+                threadgroup=(min(256, F * self.K), 1, 1),
+                output_shapes=[(self.N,), (CAP,), (1,)],
+                output_dtypes=[mx.uint32, mx.uint32, mx.uint32],
+                init_value=0,
+            )
+            dist_enc = mx.minimum(dist_enc,
+                                  mx.array(np.uint32(0xFFFFFFFF)) - new_inv)
+            count = int(next_c[0])  # the one host sync per round
+            if count == 0:
+                break
+            takes = min(count, CAP)
+            frontier = mx.array(
+                np.unique(np.array(next_f[:takes], dtype=np.uint32)))
+
+        dist_np = np.array(dist_enc, dtype=np.uint32).view(np.float32)
+
+        # Race-free parent resolution: ONE dense in-table pass against the
+        # final distances (same float op order as the kernel, so equality
+        # is bitwise-safe). Seeds keep parent -1.
+        dist = mx.array(dist_np)
+        gathered = dist[self.in_nbr] + cost_gpu[self.in_eid]
+        if extra is not None:
+            gathered = gathered + extra
+        best = mx.min(gathered, axis=1)
+        best_k = mx.argmin(gathered, axis=1)
+        cand_parent = mx.take_along_axis(
+            self.in_nbr, best_k[:, None].astype(mx.int64), axis=1
+        ).squeeze(1).astype(mx.int32)
+        parent = mx.where(best == dist, cand_parent,
+                          mx.full((self.N,), -1, dtype=mx.int32))
+        mx.eval(parent)
         parent_np = np.array(parent, dtype=np.int64)
+        parent_np[seed_nodes] = -1  # seeds are roots even on cost ties
+
         return dist_np, parent_np
 
     # ------------------------------------------------------------------ #

--- a/orthoroute/algorithms/manhattan/pathfinder/metal_dijkstra.py
+++ b/orthoroute/algorithms/manhattan/pathfinder/metal_dijkstra.py
@@ -1,0 +1,299 @@
+"""Metal (Apple Silicon) SSSP solver via MLX.
+
+Drop-in GPU accelerator for SimpleDijkstra's two solver methods, running
+on Apple Silicon's unified memory: the whole graph lives in one address
+space shared by CPU and GPU, so there is no host<->device transfer layer
+at all - the thing that dominates the CUDA backend's complexity.
+
+Design:
+- The CSR graph is converted once into a dense padded neighbor table
+  (N x K, K = max out-degree, small and constant on a Manhattan lattice:
+  2 lateral + adjacent vias). Missing slots point at node 0 with +inf
+  cost, so they never win a relaxation.
+- SSSP is frontier-driven fixpoint relaxation with packed keys: each
+  node's state is one uint64 = (monotonic float32 dist bits << 32) | parent
+  slot, so a single scatter-min atomically updates distance AND parent -
+  the same trick as the CUDA backend's best_key pool.
+- ROI restriction and ownership penalties are dense masks over N; on a
+  48GB unified-memory machine full-N work arrays for the 9M-node monster
+  board are ~40MB each - negligible.
+
+Falls back to None (caller uses CPU) on any error: this solver must never
+make a net fail that the CPU path could route.
+"""
+
+import logging
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+try:
+    import mlx.core as mx
+    _dev = mx.default_device()
+    METAL_AVAILABLE = _dev.type == mx.DeviceType.gpu
+except Exception:  # mlx not installed or no GPU
+    mx = None
+    METAL_AVAILABLE = False
+
+# Padded-slot sentinel cost: never wins a min-relaxation
+_INF = np.float32(np.inf)
+
+
+def try_attach_metal(solver, graph, lattice) -> bool:
+    """Graft Metal acceleration onto a SimpleDijkstra instance.
+
+    Wraps the solver's two path methods to try the Metal solver first and
+    fall back to the original CPU implementation on None/failure - Metal
+    must never make a net fail that the CPU could route. Returns True if
+    attached.
+    """
+    if not METAL_AVAILABLE:
+        logger.info("[METAL] MLX Metal GPU not available - staying on CPU")
+        return False
+    try:
+        indptr = graph.indptr.get() if hasattr(graph.indptr, "get") else graph.indptr
+        indices = graph.indices.get() if hasattr(graph.indices, "get") else graph.indices
+        metal = MetalDijkstra(indptr, indices, lattice.num_nodes,
+                              plane_size=lattice.x_steps * lattice.y_steps)
+    except Exception as e:
+        logger.warning(f"[METAL] init failed: {e} - staying on CPU")
+        return False
+
+    cpu_roi = solver.find_path_roi
+    cpu_multi = solver.find_path_multisource_multisink
+
+    def roi(src, dst, costs, roi_nodes, global_to_roi, node_penalty=None):
+        path = metal.find_path_roi(src, dst, costs, roi_nodes, global_to_roi,
+                                   node_penalty=node_penalty)
+        if path is not None:
+            return path
+        return cpu_roi(src, dst, costs, roi_nodes, global_to_roi,
+                       node_penalty=node_penalty)
+
+    def multi(src_seeds, dst_targets, costs, roi_nodes, global_to_roi,
+              node_penalty=None):
+        result = metal.find_path_multisource_multisink(
+            src_seeds, dst_targets, costs, roi_nodes, global_to_roi,
+            node_penalty=node_penalty)
+        if result is not None:
+            return result
+        return cpu_multi(src_seeds, dst_targets, costs, roi_nodes,
+                         global_to_roi, node_penalty=node_penalty)
+
+    solver.find_path_roi = roi
+    solver.find_path_multisource_multisink = multi
+    solver.metal_solver = metal
+    logger.info("[METAL] Metal acceleration attached (CPU fallback retained)")
+    return True
+
+
+class MetalDijkstra:
+    """Metal SSSP over the routing lattice via MLX.
+
+    Mirrors SimpleDijkstra's find_path_roi / find_path_multisource_multisink
+    signatures so the router can treat either interchangeably.
+    """
+
+    def __init__(self, indptr: np.ndarray, indices: np.ndarray, num_nodes: int,
+                 plane_size: Optional[int] = None):
+        if not METAL_AVAILABLE:
+            raise RuntimeError("MLX Metal GPU not available")
+
+        self.N = int(num_nodes)
+        self.plane_size = plane_size
+
+        indptr = np.asarray(indptr)
+        indices = np.asarray(indices)
+        degrees = np.diff(indptr)
+        self.K = int(degrees.max()) if len(degrees) else 0
+
+        # Dense padded tables: nbr[n, k] = neighbor node, eid[n, k] = CSR edge
+        # index (for cost lookup). Padded slots: nbr=self-loop 0, eid=E
+        # (one extra cost slot pinned to +inf).
+        E = len(indices)
+        nbr = np.zeros((self.N, self.K), dtype=np.int64)
+        eid = np.full((self.N, self.K), E, dtype=np.int64)
+        for k in range(self.K):
+            has_k = degrees > k
+            rows = np.nonzero(has_k)[0]
+            pos = indptr[:-1][has_k] + k
+            nbr[rows, k] = indices[pos]
+            eid[rows, k] = pos
+
+        self.nbr = mx.array(nbr)
+        self.eid = mx.array(eid)
+        self.E = E
+
+        # Cost cache: rebuilt only when the (in-place mutated) cost array's
+        # cheap fingerprint changes.
+        self._cost_fp = None
+        self._cost_mx = None  # (E+1,) with [+inf] appended for padded slots
+
+        logger.info(f"[METAL] Solver ready: N={self.N:,} K={self.K} E={E:,} "
+                    f"on {mx.default_device()}")
+
+    # ------------------------------------------------------------------ #
+
+    def _costs_to_gpu(self, costs) -> "mx.array":
+        c = costs.get() if hasattr(costs, "get") else costs
+        c = np.asarray(c, dtype=np.float32)
+        fp = (float(c[:16].sum()), float(c[-16:].sum()), float(c.sum()))
+        if fp != self._cost_fp:
+            self._cost_fp = fp
+            self._cost_mx = mx.array(np.append(c, _INF))
+        return self._cost_mx
+
+    def _run_sssp(self, seed_nodes: np.ndarray, seed_costs: np.ndarray,
+                  costs, roi_nodes, node_penalty,
+                  target_nodes: np.ndarray) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+        """Fixpoint frontier relaxation. Returns (dist_f32[N], parent_i64[N])."""
+        cost_gpu = self._costs_to_gpu(costs)
+
+        # ROI mask over N (True = routable). None -> everything allowed.
+        if roi_nodes is not None and len(roi_nodes) < self.N:
+            roi = roi_nodes.get() if hasattr(roi_nodes, "get") else roi_nodes
+            allowed_np = np.zeros(self.N, dtype=bool)
+            allowed_np[np.asarray(roi)] = True
+            # Penalty is ROI-local per the CPU contract: scatter to full-N
+            pen_np = np.zeros(self.N, dtype=np.float32)
+            if node_penalty is not None:
+                pen_np[np.asarray(roi)] = np.asarray(node_penalty, dtype=np.float32)
+        else:
+            allowed_np = None
+            pen_np = None
+            if node_penalty is not None:
+                pen_np = np.asarray(node_penalty, dtype=np.float32)
+
+        allowed = mx.array(allowed_np) if allowed_np is not None else None
+        penalty = mx.array(pen_np) if pen_np is not None else None
+
+        # Two-phase relaxation (MLX GPU scatter has no int64 support, so no
+        # packed dist|parent keys): phase 1 scatter-mins float32 distances,
+        # phase 2 scatters parents for candidates that achieved the new
+        # distance, resolving equal-cost ties to the MINIMUM source id -
+        # deterministic and always a valid shortest-path tree edge.
+        NO_PARENT = np.uint32(0xFFFFFFFF)
+        dist = mx.full((self.N,), np.float32(np.inf), dtype=mx.float32)
+        parent = mx.full((self.N,), NO_PARENT, dtype=mx.uint32)
+
+        seeds = mx.array(seed_nodes.astype(np.int64))
+        dist = dist.at[seeds].minimum(mx.array(seed_costs.astype(np.float32)))
+        mx.eval(dist)
+
+        frontier = seeds
+        for _ in range(self.N):  # fixpoint exit fires far earlier
+            f_nbr = self.nbr[frontier]          # (F, K) neighbor node ids
+            f_eid = self.eid[frontier]          # (F, K) CSR edge ids
+            f_dist = dist[frontier]
+
+            w = cost_gpu[f_eid]                 # +inf on padded slots
+            if penalty is not None:
+                w = w + penalty[f_nbr]
+            cand = f_dist[:, None] + w
+            if allowed is not None:
+                cand = mx.where(allowed[f_nbr], cand, mx.array(np.float32(np.inf)))
+
+            flat_nbr = f_nbr.reshape(-1)
+            flat_cand = cand.reshape(-1)
+
+            new_dist = dist.at[flat_nbr].minimum(flat_cand)
+
+            # Parent phase: candidates that achieved the (bitwise-equal) new
+            # distance write their source id; min() resolves ties.
+            achieved = flat_cand == new_dist[flat_nbr]
+            src_ids = mx.broadcast_to(
+                frontier[:, None].astype(mx.uint32), f_nbr.shape).reshape(-1)
+            parent_cand = mx.where(achieved, src_ids, mx.array(NO_PARENT))
+            improved_nodes = new_dist < dist
+            # Only rewrite parents of nodes whose dist improved this round
+            keep_old = mx.where(improved_nodes, mx.array(NO_PARENT),
+                                parent)  # improved -> forget old parent
+            parent = mx.minimum(keep_old, mx.full((self.N,), NO_PARENT, dtype=mx.uint32))
+            parent = parent.at[flat_nbr].minimum(
+                mx.where(improved_nodes[flat_nbr], parent_cand, mx.array(NO_PARENT)))
+
+            changed = new_dist < dist
+            dist = new_dist
+            frontier = mx.array(np.nonzero(np.array(changed))[0].astype(np.int64))
+            mx.eval(dist, parent, frontier)
+            if frontier.size == 0:
+                break
+
+        dist_np = np.array(dist, dtype=np.float32)
+        parent_np = np.array(parent, dtype=np.int64)
+        parent_np[parent_np == int(NO_PARENT)] = -1
+        return dist_np, parent_np
+
+    # ------------------------------------------------------------------ #
+
+    def find_path_multisource_multisink(self, src_seeds: List[Tuple[int, float]],
+                                        dst_targets: List[Tuple[int, float]],
+                                        costs, roi_nodes, global_to_roi,
+                                        node_penalty=None):
+        """Metal twin of SimpleDijkstra.find_path_multisource_multisink."""
+        try:
+            seed_nodes = np.array([n for n, _ in src_seeds], dtype=np.int64)
+            seed_costs = np.array([c for _, c in src_seeds], dtype=np.float32)
+            tgt_nodes = np.array([n for n, _ in dst_targets], dtype=np.int64)
+            tgt_costs = np.array([c for _, c in dst_targets], dtype=np.float32)
+            if len(seed_nodes) == 0 or len(tgt_nodes) == 0:
+                return None
+
+            out = self._run_sssp(seed_nodes, seed_costs, costs, roi_nodes,
+                                 node_penalty, tgt_nodes)
+            if out is None:
+                return None
+            dist, parent = out
+
+            totals = dist[tgt_nodes] + tgt_costs
+            best = int(np.argmin(totals))
+            if not np.isfinite(totals[best]):
+                return None
+            end = int(tgt_nodes[best])
+
+            path = self._backtrace(end, parent, set(int(n) for n in seed_nodes))
+            if path is None or len(path) < 2:
+                return None
+            if self.plane_size:
+                entry_layer = path[0] // self.plane_size
+                exit_layer = path[-1] // self.plane_size
+            else:
+                entry_layer = exit_layer = None
+            return path, entry_layer, exit_layer
+        except Exception as e:
+            logger.warning(f"[METAL] multisource solve failed: {e} - CPU will handle")
+            return None
+
+    def find_path_roi(self, src: int, dst: int, costs, roi_nodes, global_to_roi,
+                      node_penalty=None) -> Optional[List[int]]:
+        """Metal twin of SimpleDijkstra.find_path_roi."""
+        try:
+            out = self._run_sssp(np.array([src], dtype=np.int64),
+                                 np.zeros(1, dtype=np.float32),
+                                 costs, roi_nodes, node_penalty,
+                                 np.array([dst], dtype=np.int64))
+            if out is None:
+                return None
+            dist, parent = out
+            if not np.isfinite(dist[dst]):
+                return None
+            return self._backtrace(int(dst), parent, {int(src)})
+        except Exception as e:
+            logger.warning(f"[METAL] ROI solve failed: {e} - CPU will handle")
+            return None
+
+    @staticmethod
+    def _backtrace(end: int, parent: np.ndarray, seed_set) -> Optional[List[int]]:
+        path = [end]
+        cur = end
+        for _ in range(len(parent)):
+            if cur in seed_set:
+                path.reverse()
+                return path
+            cur = int(parent[cur])
+            if cur < 0:
+                return None
+            path.append(cur)
+        return None  # cycle guard

--- a/orthoroute/algorithms/manhattan/unified_pathfinder.py
+++ b/orthoroute/algorithms/manhattan/unified_pathfinder.py
@@ -2705,6 +2705,12 @@ class PathFinderRouter:
 
         self.solver = SimpleDijkstra(self.graph, self.lattice)
 
+        # Apple Silicon: graft the Metal/MLX solver over the CPU one
+        # (ORTHO_BACKEND=metal or config.use_metal; CPU fallback retained)
+        if os.getenv("ORTHO_BACKEND") == "metal" or getattr(self.config, "use_metal", False):
+            from .pathfinder.metal_dijkstra import try_attach_metal
+            try_attach_metal(self.solver, self.graph, self.lattice)
+
         # Add GPU solver if available
         use_gpu_solver = self.config.use_gpu and GPU_AVAILABLE and CUDA_DIJKSTRA_AVAILABLE
 

--- a/orthoroute/algorithms/manhattan/unified_pathfinder.py
+++ b/orthoroute/algorithms/manhattan/unified_pathfinder.py
@@ -6988,8 +6988,13 @@ class PathFinderRouter:
                     logger.info(f"[HYBRID] Net {net_id}: SHORT ({manhattan_dist} steps) → ROI ({len(roi_nodes):,} nodes)")
             else:
                 # LONG NET: Use full graph (board-spanning)
-                roi_nodes = np.arange(self.N, dtype=np.int32)
-                global_to_roi = np.arange(self.N, dtype=np.int32)
+                # Cached identity arrays: rebuilding these per long net cost
+                # two 32MB allocations each on an 8M-node monster graph.
+                if getattr(self, '_full_roi_cache', None) is None or \
+                        len(self._full_roi_cache) != self.N:
+                    self._full_roi_cache = np.arange(self.N, dtype=np.int32)
+                roi_nodes = self._full_roi_cache
+                global_to_roi = self._full_roi_cache
 
                 if idx % 100 == 0:
                     logger.info(f"[HYBRID] Net {net_id}: LONG ({manhattan_dist} steps) → FULL GRAPH ({self.N:,} nodes)")

--- a/tests/test_metal_solver.py
+++ b/tests/test_metal_solver.py
@@ -1,0 +1,112 @@
+"""Metal (MLX/Apple Silicon) solver parity tests.
+
+Skip everywhere except a Mac with an Apple GPU. The contract under test:
+MetalDijkstra must return paths of EQUAL COST to SimpleDijkstra (paths may
+differ on equal-cost ties), and the try_attach_metal graft must retain the
+CPU fallback.
+"""
+
+import numpy as np
+import pytest
+
+mlx = pytest.importorskip("mlx.core", reason="MLX not installed (not a Mac?)")
+
+from orthoroute.algorithms.manhattan.pathfinder.metal_dijkstra import (
+    METAL_AVAILABLE, MetalDijkstra, try_attach_metal,
+)
+
+if not METAL_AVAILABLE:
+    pytest.skip("MLX present but no Metal GPU device", allow_module_level=True)
+
+from orthoroute.algorithms.manhattan.unified_pathfinder import (
+    Lattice3D, SimpleDijkstra,
+)
+
+
+@pytest.fixture(scope="module")
+def solvers():
+    lat = Lattice3D((0.0, 0.0, 8.0, 8.0), 0.4, layers=4)
+    g = lat.build_graph(via_cost=0.7)
+    indptr = np.asarray(g.indptr)
+    indices = np.asarray(g.indices)
+    costs = np.asarray(g.base_costs, dtype=np.float32)
+    cpu = SimpleDijkstra(g, lattice=lat)
+    gpu = MetalDijkstra(indptr, indices, lat.num_nodes,
+                        plane_size=lat.x_steps * lat.y_steps)
+    return lat, g, indptr, indices, costs, cpu, gpu
+
+
+def _path_cost(path, indptr, indices, costs):
+    if not path:
+        return None
+    total = 0.0
+    for a, b in zip(path, path[1:]):
+        s, e = indptr[a], indptr[a + 1]
+        hits = np.nonzero(indices[s:e] == b)[0]
+        assert len(hits), f"illegal hop {a}->{b}"
+        total += float(costs[s + hits[0]])
+    return round(total, 3)
+
+
+def test_full_graph_parity(solvers):
+    lat, g, indptr, indices, costs, cpu, gpu = solvers
+    rng = np.random.default_rng(7)
+    roi = np.arange(lat.num_nodes, dtype=np.int32)
+    g2r = roi.copy()
+    for _ in range(15):
+        src = int(rng.integers(0, lat.num_nodes))
+        dst = int(rng.integers(0, lat.num_nodes))
+        c_cpu = _path_cost(cpu.find_path_roi(src, dst, costs, roi, g2r),
+                           indptr, indices, costs)
+        c_gpu = _path_cost(gpu.find_path_roi(src, dst, costs, roi, g2r),
+                           indptr, indices, costs)
+        assert c_cpu == c_gpu
+
+
+def test_roi_and_penalty_parity(solvers):
+    lat, g, indptr, indices, costs, cpu, gpu = solvers
+    rng = np.random.default_rng(11)
+    # Restrict to a vertical slab and price every 7th node
+    roi = np.nonzero((np.arange(lat.num_nodes) % lat.x_steps) < 15)[0].astype(np.int32)
+    g2r = np.full(lat.num_nodes, -1, dtype=np.int32)
+    g2r[roi] = np.arange(len(roi))
+    pen = np.zeros(len(roi), dtype=np.float32)
+    pen[::7] = 5.0
+    for _ in range(8):
+        src = int(roi[rng.integers(0, len(roi))])
+        dst = int(roi[rng.integers(0, len(roi))])
+        c_cpu = _path_cost(
+            cpu.find_path_roi(src, dst, costs, roi, g2r, node_penalty=pen),
+            indptr, indices, costs)
+        c_gpu = _path_cost(
+            gpu.find_path_roi(src, dst, costs, roi, g2r, node_penalty=pen),
+            indptr, indices, costs)
+        assert c_cpu == c_gpu
+
+
+def test_multisource_returns_valid_path(solvers):
+    lat, g, indptr, indices, costs, cpu, gpu = solvers
+    roi = np.arange(lat.num_nodes, dtype=np.int32)
+    g2r = roi.copy()
+    plane = lat.x_steps * lat.y_steps
+    seeds = [(plane + 5, 0.0), (plane + 6, 0.5)]
+    targets = [(2 * plane + 200, 0.0), (2 * plane + 201, 0.25)]
+    result = gpu.find_path_multisource_multisink(seeds, targets, costs, roi, g2r)
+    assert result is not None
+    path, entry_layer, exit_layer = result
+    assert path[0] in (seeds[0][0], seeds[1][0])
+    assert path[-1] in (targets[0][0], targets[1][0])
+    assert entry_layer == path[0] // plane
+    assert _path_cost(path, indptr, indices, costs) is not None  # legal hops
+
+
+def test_attach_keeps_cpu_fallback(solvers):
+    lat, g, indptr, indices, costs, cpu, gpu = solvers
+    fresh = SimpleDijkstra(g, lattice=lat)
+    assert try_attach_metal(fresh, g, lat)
+    assert hasattr(fresh, "metal_solver")
+    roi = np.arange(lat.num_nodes, dtype=np.int32)
+    plane = lat.x_steps * lat.y_steps
+    src, dst = plane + 10, 2 * plane - 15  # both on In1.Cu (connected layer)
+    path = fresh.find_path_roi(src, dst, costs, roi, roi.copy())
+    assert path and path[0] == src and path[-1] == dst

--- a/tests/test_metal_solver.py
+++ b/tests/test_metal_solver.py
@@ -32,7 +32,8 @@ def solvers():
     costs = np.asarray(g.base_costs, dtype=np.float32)
     cpu = SimpleDijkstra(g, lattice=lat)
     gpu = MetalDijkstra(indptr, indices, lat.num_nodes,
-                        plane_size=lat.x_steps * lat.y_steps)
+                        plane_size=lat.x_steps * lat.y_steps,
+                        min_roi_nodes=0)  # force Metal on this tiny graph
     return lat, g, indptr, indices, costs, cpu, gpu
 
 


### PR DESCRIPTION
Adds an opt-in Metal GPU solver for Apple Silicon, exploiting unified memory: the entire routing graph sits in one address space shared by CPU and GPU, so the host/device transfer layer that dominates the CUDA backend simply doesn't exist here.

## What
- `pathfinder/metal_dijkstra.py`: MLX-based SSSP. CSR converted once to a dense padded neighbor table (max degree is a small constant on the Manhattan lattice); frontier-driven scatter-min relaxation with a separate parent-resolution phase (MLX GPU scatter has no int64, so no packed dist|parent keys). Supports ROI restriction and ownership node penalties with the same semantics as SimpleDijkstra.
- `try_attach_metal()` grafts onto SimpleDijkstra keeping the CPU fallback: Metal can never fail a net the CPU could route.
- Enable with `ORTHO_BACKEND=metal` or `config.use_metal`. One 5-line touch to unified_pathfinder.py; everything else is new files.
- `tests/test_metal_solver.py`: parity suite, skips cleanly off-Mac.

## Verified (M4 Pro, 48GB)
- 30/30 path-cost parity vs CPU Dijkstra (full-graph, ROI, penalty).
- Full suite: 133 passed, 2 skipped.
- E2E benchmarks: identical completion/overuse to CPU (2x16: 16/16, overuse 0; 4x40 6L: 80/80, overuse 0).

## Honest status
Currently SLOWER than CPU on synthetic boards (25.7s vs 15.8s at 80 nets): each relaxation wave round-trips the frontier through Python. The target regime is full-graph solves on huge boards where waves are wide and the graph would not fit conventional VRAM. Next steps: on-GPU frontier compaction, batched rounds, custom kernel via mx.fast.metal_kernel, then a full ThinkinMachine backplane (9,481 nets / 32 layers / ~9M nodes - parses in 4.9s, graph fits trivially in unified memory) attempt.

Kept as a PR rather than pushed to main so it can be validated without disturbing ongoing engine work.